### PR TITLE
Typo: web-2 needs to be web-1

### DIFF
--- a/kubernetes-101/README.md
+++ b/kubernetes-101/README.md
@@ -335,7 +335,7 @@ spec:
 ```
 kubectl exec -it web-0 -- bash
 echo "Hello from Saiyam" >> /usr/share/nginx/html/index.html
-kubectl exec -it web-2 -- bash
+kubectl exec -it web-1 -- bash
 echo "Hello from Saiyam" >> /usr/share/nginx/html/index.html
 
 ```


### PR DESCRIPTION
In the Statefulset section:

Instead of:

kubectl exec -it web-2 -- bash  

the below needs to be used:

kubectl exec -it web-1 -- bash