### PR TITLE
Expected version "^14.15.0 || ^16.10.0 || >=18.0.0" error with yarn install

### DIFF
--- a/linux-docker-fundamentals/Dockerfiles/novice/Dockerfile
+++ b/linux-docker-fundamentals/Dockerfiles/novice/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 COPY . .
 
 # runs a command and creates an image layer. Used to install packages into containers
-RUN yarn install --production
+RUN yarn install --production --ignore-engines
 
 # provides a command and arguments for an executing container. Parameters can be overridden. There can be ONLY one CMD.
 CMD ["node", "src/index.js"]


### PR DESCRIPTION
error jest@29.3.1: The engine "node" is incompatible with this module. Expected version "^14.15.0 || ^16.10.0 || >=18.0.0". Got "12.22.12" error Found incompatible module.